### PR TITLE
Add GNU Radio 3.10 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@
 * start the dummy0 interface: *sudo ifconfig dummy0 up*
 * run dectrcv as root: *sudo ./dectrcv*
 * start the SDR part: 
-    * If you use gnuradio version <= 3.7 : *./dectrx_37.py*
+    * If you use gnuradio version >= 3.10 : *./dectrx_310.py*
     * If you use gnuradio version >= 3.8 : *./dectrx_38.py*
+    * If you use gnuradio version <= 3.7 : *./dectrx_37.py*
 * set channel, gain values and ppm
 * enjoy the DECT packets in **wireshark**
 

--- a/SDR/dect_multirx_310.grc
+++ b/SDR/dect_multirx_310.grc
@@ -1,0 +1,1580 @@
+options:
+  parameters:
+    author: ''
+    category: Custom
+    cmake_opt: ''
+    comment: ''
+    copyright: ''
+    description: ''
+    gen_cmake: 'On'
+    gen_linking: dynamic
+    generate_options: qt_gui
+    hier_block_src_path: '.:'
+    id: dect_multirx_310
+    max_nouts: '0'
+    output_language: python
+    placement: (0,0)
+    qt_qss_theme: ''
+    realtime_scheduling: ''
+    run: 'True'
+    run_command: '{python} -u {filename}'
+    run_options: prompt
+    sizing_mode: fixed
+    thread_safe_setters: ''
+    title: ''
+    window_size: ''
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 8]
+    rotation: 0
+    state: enabled
+
+blocks:
+- name: atten
+  id: variable
+  parameters:
+    comment: ''
+    value: '60'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [131, 629]
+    rotation: 0
+    state: enabled
+- name: bb_freq
+  id: variable
+  parameters:
+    comment: ''
+    value: 1897.344e6-(5*1.728e6)
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [176, 5]
+    rotation: 0
+    state: enabled
+- name: bb_gain
+  id: variable
+  parameters:
+    comment: ''
+    value: '20'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [460, 6]
+    rotation: 0
+    state: true
+- name: ch_bw
+  id: variable
+  parameters:
+    comment: ''
+    value: 1.728e6
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [32, 709]
+    rotation: 0
+    state: enabled
+- name: ch_tb
+  id: variable
+  parameters:
+    comment: ''
+    value: 1.728e6-symbol_rate
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [32, 629]
+    rotation: 0
+    state: enabled
+- name: channels
+  id: variable
+  parameters:
+    comment: ''
+    value: '11'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [376, 5]
+    rotation: 0
+    state: enabled
+- name: if_gain
+  id: variable
+  parameters:
+    comment: ''
+    value: '20'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [618, 5]
+    rotation: 0
+    state: true
+- name: pfb_taps
+  id: variable
+  parameters:
+    comment: ''
+    value: firdes.low_pass_2(1, samp_rate, ch_bw, ch_tb, atten, window.WIN_HANN)
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [136, 709]
+    rotation: 0
+    state: enabled
+- name: ppm
+  id: variable
+  parameters:
+    comment: ''
+    value: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [695, 6]
+    rotation: 0
+    state: true
+- name: range_bb_gain
+  id: variable_qtgui_range
+  parameters:
+    comment: ''
+    gui_hint: ''
+    label: BB Gain
+    min_len: '200'
+    orient: Qt.Horizontal
+    rangeType: float
+    start: '0'
+    step: '1'
+    stop: '100'
+    value: bb_gain
+    widget: counter_slider
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [31, 792]
+    rotation: 0
+    state: true
+- name: range_if_gain
+  id: variable_qtgui_range
+  parameters:
+    comment: ''
+    gui_hint: ''
+    label: IF Gain
+    min_len: '200'
+    orient: Qt.Horizontal
+    rangeType: float
+    start: '0'
+    step: '1'
+    stop: '100'
+    value: if_gain
+    widget: counter_slider
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [292, 794]
+    rotation: 0
+    state: true
+- name: range_ppm
+  id: variable_qtgui_range
+  parameters:
+    comment: ''
+    gui_hint: ''
+    label: PPM
+    min_len: '200'
+    orient: Qt.Horizontal
+    rangeType: float
+    start: '-70'
+    step: '1'
+    stop: '70'
+    value: ppm
+    widget: counter_slider
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [164, 794]
+    rotation: 0
+    state: true
+- name: range_rf_gain
+  id: variable_qtgui_range
+  parameters:
+    comment: ''
+    gui_hint: ''
+    label: RF Gain
+    min_len: '200'
+    orient: Qt.Horizontal
+    rangeType: float
+    start: '0'
+    step: '1'
+    stop: '100'
+    value: rf_gain
+    widget: counter_slider
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [419, 794]
+    rotation: 0
+    state: true
+- name: rf_gain
+  id: variable
+  parameters:
+    comment: ''
+    value: '10'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [545, 7]
+    rotation: 0
+    state: true
+- name: samp_rate
+  id: variable
+  parameters:
+    comment: ''
+    value: 20e6
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [280, 5]
+    rotation: 0
+    state: enabled
+- name: symbol_rate
+  id: variable
+  parameters:
+    comment: ''
+    value: 1.152e6
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [24, 93]
+    rotation: 0
+    state: enabled
+- name: total_bw
+  id: variable
+  parameters:
+    comment: ''
+    value: ch_bw*channels
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [210, 632]
+    rotation: 0
+    state: enabled
+- name: blocks_null_sink_0
+  id: blocks_null_sink
+  parameters:
+    affinity: ''
+    alias: ''
+    bus_structure_sink: '[[0,],]'
+    comment: ''
+    num_inputs: '1'
+    type: complex
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [829, 31]
+    rotation: 0
+    state: enabled
+- name: blocks_pack_k_bits_bb_0
+  id: blocks_pack_k_bits_bb
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    k: '8'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1213, 106]
+    rotation: 0
+    state: enabled
+- name: blocks_pack_k_bits_bb_0_0
+  id: blocks_pack_k_bits_bb
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    k: '8'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1213, 202]
+    rotation: 0
+    state: enabled
+- name: blocks_pack_k_bits_bb_0_0_0
+  id: blocks_pack_k_bits_bb
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    k: '8'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1213, 298]
+    rotation: 0
+    state: enabled
+- name: blocks_pack_k_bits_bb_0_0_0_0
+  id: blocks_pack_k_bits_bb
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    k: '8'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1213, 586]
+    rotation: 0
+    state: enabled
+- name: blocks_pack_k_bits_bb_0_0_0_0_0
+  id: blocks_pack_k_bits_bb
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    k: '8'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1213, 970]
+    rotation: 0
+    state: enabled
+- name: blocks_pack_k_bits_bb_0_0_0_1
+  id: blocks_pack_k_bits_bb
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    k: '8'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1213, 682]
+    rotation: 0
+    state: enabled
+- name: blocks_pack_k_bits_bb_0_0_1
+  id: blocks_pack_k_bits_bb
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    k: '8'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1213, 490]
+    rotation: 0
+    state: enabled
+- name: blocks_pack_k_bits_bb_0_0_1_0
+  id: blocks_pack_k_bits_bb
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    k: '8'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1213, 874]
+    rotation: 0
+    state: enabled
+- name: blocks_pack_k_bits_bb_0_1
+  id: blocks_pack_k_bits_bb
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    k: '8'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1213, 394]
+    rotation: 0
+    state: enabled
+- name: blocks_pack_k_bits_bb_0_1_0
+  id: blocks_pack_k_bits_bb
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    k: '8'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1213, 778]
+    rotation: 0
+    state: enabled
+- name: blocks_udp_sink_0
+  id: network_udp_sink
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    send_eof: 'True'
+    addr: 127.0.0.1
+    port: '2323'
+    payloadsize: '1472'
+    type: byte
+    vlen: '1'
+    header: 0
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1349, 85]
+    rotation: 0
+    state: enabled
+- name: blocks_udp_sink_0_0
+  id: network_udp_sink
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    send_eof: 'True'
+    addr: 127.0.0.1
+    port: '2324'
+    payloadsize: '1472'
+    type: byte
+    vlen: '1'
+    header: 0
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1349, 181]
+    rotation: 0
+    state: enabled
+- name: blocks_udp_sink_0_0_0
+  id: network_udp_sink
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    send_eof: 'True'
+    addr: 127.0.0.1
+    port: '2325'
+    payloadsize: '1472'
+    type: byte
+    vlen: '1'
+    header: 0
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1349, 277]
+    rotation: 0
+    state: enabled
+- name: blocks_udp_sink_0_0_0_0
+  id: network_udp_sink
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    send_eof: 'True'
+    addr: 127.0.0.1
+    port: '2328'
+    payloadsize: '1472'
+    type: byte
+    vlen: '1'
+    header: 0
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1349, 557]
+    rotation: 0
+    state: enabled
+- name: blocks_udp_sink_0_0_0_0_0
+  id: network_udp_sink
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    send_eof: 'True'
+    addr: 127.0.0.1
+    port: '2332'
+    payloadsize: '1472'
+    type: byte
+    vlen: '1'
+    header: 0
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1349, 941]
+    rotation: 0
+    state: enabled
+- name: blocks_udp_sink_0_0_0_1
+  id: network_udp_sink
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    send_eof: 'True'
+    addr: 127.0.0.1
+    port: '2329'
+    payloadsize: '1472'
+    type: byte
+    vlen: '1'
+    header: 0
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1349, 661]
+    rotation: 0
+    state: enabled
+- name: blocks_udp_sink_0_0_1
+  id: network_udp_sink
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    send_eof: 'True'
+    addr: 127.0.0.1
+    port: '2327'
+    payloadsize: '1472'
+    type: byte
+    vlen: '1'
+    header: 0
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1349, 461]
+    rotation: 0
+    state: enabled
+- name: blocks_udp_sink_0_0_1_0
+  id: network_udp_sink
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    send_eof: 'True'
+    addr: 127.0.0.1
+    port: '2331'
+    payloadsize: '1472'
+    type: byte
+    vlen: '1'
+    header: 0
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1349, 845]
+    rotation: 0
+    state: enabled
+- name: blocks_udp_sink_0_1
+  id: network_udp_sink
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    send_eof: 'True'
+    addr: 127.0.0.1
+    port: '2326'
+    payloadsize: '1472'
+    type: byte
+    vlen: '1'
+    header: 0
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1349, 365]
+    rotation: 0
+    state: enabled
+- name: blocks_udp_sink_0_1_0
+  id: network_udp_sink
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    send_eof: 'True'
+    addr: 127.0.0.1
+    port: '2330'
+    payloadsize: '1472'
+    type: byte
+    vlen: '1'
+    header: 0
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1349, 749]
+    rotation: 0
+    state: enabled
+- name: digital_gmsk_demod_0
+  id: digital_gmsk_demod
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    freq_error: '0'
+    gain_mu: '0.175'
+    log: 'False'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    mu: '0.5'
+    omega_relative_limit: '0.005'
+    samples_per_symbol: '2'
+    verbose: 'False'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1005, 78]
+    rotation: 0
+    state: enabled
+- name: digital_gmsk_demod_0_0
+  id: digital_gmsk_demod
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    freq_error: '0'
+    gain_mu: '0.175'
+    log: 'False'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    mu: '0.5'
+    omega_relative_limit: '0.005'
+    samples_per_symbol: '2'
+    verbose: 'False'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1005, 174]
+    rotation: 0
+    state: enabled
+- name: digital_gmsk_demod_0_0_0
+  id: digital_gmsk_demod
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    freq_error: '0'
+    gain_mu: '0.175'
+    log: 'False'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    mu: '0.5'
+    omega_relative_limit: '0.005'
+    samples_per_symbol: '2'
+    verbose: 'False'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1005, 270]
+    rotation: 0
+    state: enabled
+- name: digital_gmsk_demod_0_0_0_0
+  id: digital_gmsk_demod
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    freq_error: '0'
+    gain_mu: '0.175'
+    log: 'False'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    mu: '0.5'
+    omega_relative_limit: '0.005'
+    samples_per_symbol: '2'
+    verbose: 'False'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1005, 558]
+    rotation: 0
+    state: enabled
+- name: digital_gmsk_demod_0_0_0_0_0
+  id: digital_gmsk_demod
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    freq_error: '0'
+    gain_mu: '0.175'
+    log: 'False'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    mu: '0.5'
+    omega_relative_limit: '0.005'
+    samples_per_symbol: '2'
+    verbose: 'False'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1005, 942]
+    rotation: 0
+    state: enabled
+- name: digital_gmsk_demod_0_0_0_1
+  id: digital_gmsk_demod
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    freq_error: '0'
+    gain_mu: '0.175'
+    log: 'False'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    mu: '0.5'
+    omega_relative_limit: '0.005'
+    samples_per_symbol: '2'
+    verbose: 'False'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1005, 654]
+    rotation: 0
+    state: enabled
+- name: digital_gmsk_demod_0_0_1
+  id: digital_gmsk_demod
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    freq_error: '0'
+    gain_mu: '0.175'
+    log: 'False'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    mu: '0.5'
+    omega_relative_limit: '0.005'
+    samples_per_symbol: '2'
+    verbose: 'False'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1005, 462]
+    rotation: 0
+    state: enabled
+- name: digital_gmsk_demod_0_0_1_0
+  id: digital_gmsk_demod
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    freq_error: '0'
+    gain_mu: '0.175'
+    log: 'False'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    mu: '0.5'
+    omega_relative_limit: '0.005'
+    samples_per_symbol: '2'
+    verbose: 'False'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1005, 846]
+    rotation: 0
+    state: enabled
+- name: digital_gmsk_demod_0_1
+  id: digital_gmsk_demod
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    freq_error: '0'
+    gain_mu: '0.175'
+    log: 'False'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    mu: '0.5'
+    omega_relative_limit: '0.005'
+    samples_per_symbol: '2'
+    verbose: 'False'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1005, 366]
+    rotation: 0
+    state: enabled
+- name: digital_gmsk_demod_0_1_0
+  id: digital_gmsk_demod
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    freq_error: '0'
+    gain_mu: '0.175'
+    log: 'False'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    mu: '0.5'
+    omega_relative_limit: '0.005'
+    samples_per_symbol: '2'
+    verbose: 'False'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1005, 750]
+    rotation: 0
+    state: enabled
+- name: osmosdr_source_0
+  id: osmosdr_source
+  parameters:
+    affinity: ''
+    alias: ''
+    ant0: ''
+    ant1: ''
+    ant10: ''
+    ant11: ''
+    ant12: ''
+    ant13: ''
+    ant14: ''
+    ant15: ''
+    ant16: ''
+    ant17: ''
+    ant18: ''
+    ant19: ''
+    ant2: ''
+    ant20: ''
+    ant21: ''
+    ant22: ''
+    ant23: ''
+    ant24: ''
+    ant25: ''
+    ant26: ''
+    ant27: ''
+    ant28: ''
+    ant29: ''
+    ant3: ''
+    ant30: ''
+    ant31: ''
+    ant4: ''
+    ant5: ''
+    ant6: ''
+    ant7: ''
+    ant8: ''
+    ant9: ''
+    args: ''
+    bb_gain0: bb_gain
+    bb_gain1: '20'
+    bb_gain10: '20'
+    bb_gain11: '20'
+    bb_gain12: '20'
+    bb_gain13: '20'
+    bb_gain14: '20'
+    bb_gain15: '20'
+    bb_gain16: '20'
+    bb_gain17: '20'
+    bb_gain18: '20'
+    bb_gain19: '20'
+    bb_gain2: '20'
+    bb_gain20: '20'
+    bb_gain21: '20'
+    bb_gain22: '20'
+    bb_gain23: '20'
+    bb_gain24: '20'
+    bb_gain25: '20'
+    bb_gain26: '20'
+    bb_gain27: '20'
+    bb_gain28: '20'
+    bb_gain29: '20'
+    bb_gain3: '20'
+    bb_gain30: '20'
+    bb_gain31: '20'
+    bb_gain4: '20'
+    bb_gain5: '20'
+    bb_gain6: '20'
+    bb_gain7: '20'
+    bb_gain8: '20'
+    bb_gain9: '20'
+    bw0: 20e6
+    bw1: '0'
+    bw10: '0'
+    bw11: '0'
+    bw12: '0'
+    bw13: '0'
+    bw14: '0'
+    bw15: '0'
+    bw16: '0'
+    bw17: '0'
+    bw18: '0'
+    bw19: '0'
+    bw2: '0'
+    bw20: '0'
+    bw21: '0'
+    bw22: '0'
+    bw23: '0'
+    bw24: '0'
+    bw25: '0'
+    bw26: '0'
+    bw27: '0'
+    bw28: '0'
+    bw29: '0'
+    bw3: '0'
+    bw30: '0'
+    bw31: '0'
+    bw4: '0'
+    bw5: '0'
+    bw6: '0'
+    bw7: '0'
+    bw8: '0'
+    bw9: '0'
+    clock_source0: ''
+    clock_source1: ''
+    clock_source2: ''
+    clock_source3: ''
+    clock_source4: ''
+    clock_source5: ''
+    clock_source6: ''
+    clock_source7: ''
+    comment: ''
+    corr0: ppm
+    corr1: '0'
+    corr10: '0'
+    corr11: '0'
+    corr12: '0'
+    corr13: '0'
+    corr14: '0'
+    corr15: '0'
+    corr16: '0'
+    corr17: '0'
+    corr18: '0'
+    corr19: '0'
+    corr2: '0'
+    corr20: '0'
+    corr21: '0'
+    corr22: '0'
+    corr23: '0'
+    corr24: '0'
+    corr25: '0'
+    corr26: '0'
+    corr27: '0'
+    corr28: '0'
+    corr29: '0'
+    corr3: '0'
+    corr30: '0'
+    corr31: '0'
+    corr4: '0'
+    corr5: '0'
+    corr6: '0'
+    corr7: '0'
+    corr8: '0'
+    corr9: '0'
+    dc_offset_mode0: '0'
+    dc_offset_mode1: '0'
+    dc_offset_mode10: '0'
+    dc_offset_mode11: '0'
+    dc_offset_mode12: '0'
+    dc_offset_mode13: '0'
+    dc_offset_mode14: '0'
+    dc_offset_mode15: '0'
+    dc_offset_mode16: '0'
+    dc_offset_mode17: '0'
+    dc_offset_mode18: '0'
+    dc_offset_mode19: '0'
+    dc_offset_mode2: '0'
+    dc_offset_mode20: '0'
+    dc_offset_mode21: '0'
+    dc_offset_mode22: '0'
+    dc_offset_mode23: '0'
+    dc_offset_mode24: '0'
+    dc_offset_mode25: '0'
+    dc_offset_mode26: '0'
+    dc_offset_mode27: '0'
+    dc_offset_mode28: '0'
+    dc_offset_mode29: '0'
+    dc_offset_mode3: '0'
+    dc_offset_mode30: '0'
+    dc_offset_mode31: '0'
+    dc_offset_mode4: '0'
+    dc_offset_mode5: '0'
+    dc_offset_mode6: '0'
+    dc_offset_mode7: '0'
+    dc_offset_mode8: '0'
+    dc_offset_mode9: '0'
+    freq0: bb_freq
+    freq1: 100e6
+    freq10: 100e6
+    freq11: 100e6
+    freq12: 100e6
+    freq13: 100e6
+    freq14: 100e6
+    freq15: 100e6
+    freq16: 100e6
+    freq17: 100e6
+    freq18: 100e6
+    freq19: 100e6
+    freq2: 100e6
+    freq20: 100e6
+    freq21: 100e6
+    freq22: 100e6
+    freq23: 100e6
+    freq24: 100e6
+    freq25: 100e6
+    freq26: 100e6
+    freq27: 100e6
+    freq28: 100e6
+    freq29: 100e6
+    freq3: 100e6
+    freq30: 100e6
+    freq31: 100e6
+    freq4: 100e6
+    freq5: 100e6
+    freq6: 100e6
+    freq7: 100e6
+    freq8: 100e6
+    freq9: 100e6
+    gain0: rf_gain
+    gain1: '10'
+    gain10: '10'
+    gain11: '10'
+    gain12: '10'
+    gain13: '10'
+    gain14: '10'
+    gain15: '10'
+    gain16: '10'
+    gain17: '10'
+    gain18: '10'
+    gain19: '10'
+    gain2: '10'
+    gain20: '10'
+    gain21: '10'
+    gain22: '10'
+    gain23: '10'
+    gain24: '10'
+    gain25: '10'
+    gain26: '10'
+    gain27: '10'
+    gain28: '10'
+    gain29: '10'
+    gain3: '10'
+    gain30: '10'
+    gain31: '10'
+    gain4: '10'
+    gain5: '10'
+    gain6: '10'
+    gain7: '10'
+    gain8: '10'
+    gain9: '10'
+    gain_mode0: 'False'
+    gain_mode1: 'False'
+    gain_mode10: 'False'
+    gain_mode11: 'False'
+    gain_mode12: 'False'
+    gain_mode13: 'False'
+    gain_mode14: 'False'
+    gain_mode15: 'False'
+    gain_mode16: 'False'
+    gain_mode17: 'False'
+    gain_mode18: 'False'
+    gain_mode19: 'False'
+    gain_mode2: 'False'
+    gain_mode20: 'False'
+    gain_mode21: 'False'
+    gain_mode22: 'False'
+    gain_mode23: 'False'
+    gain_mode24: 'False'
+    gain_mode25: 'False'
+    gain_mode26: 'False'
+    gain_mode27: 'False'
+    gain_mode28: 'False'
+    gain_mode29: 'False'
+    gain_mode3: 'False'
+    gain_mode30: 'False'
+    gain_mode31: 'False'
+    gain_mode4: 'False'
+    gain_mode5: 'False'
+    gain_mode6: 'False'
+    gain_mode7: 'False'
+    gain_mode8: 'False'
+    gain_mode9: 'False'
+    if_gain0: if_gain
+    if_gain1: '20'
+    if_gain10: '20'
+    if_gain11: '20'
+    if_gain12: '20'
+    if_gain13: '20'
+    if_gain14: '20'
+    if_gain15: '20'
+    if_gain16: '20'
+    if_gain17: '20'
+    if_gain18: '20'
+    if_gain19: '20'
+    if_gain2: '20'
+    if_gain20: '20'
+    if_gain21: '20'
+    if_gain22: '20'
+    if_gain23: '20'
+    if_gain24: '20'
+    if_gain25: '20'
+    if_gain26: '20'
+    if_gain27: '20'
+    if_gain28: '20'
+    if_gain29: '20'
+    if_gain3: '20'
+    if_gain30: '20'
+    if_gain31: '20'
+    if_gain4: '20'
+    if_gain5: '20'
+    if_gain6: '20'
+    if_gain7: '20'
+    if_gain8: '20'
+    if_gain9: '20'
+    iq_balance_mode0: '0'
+    iq_balance_mode1: '0'
+    iq_balance_mode10: '0'
+    iq_balance_mode11: '0'
+    iq_balance_mode12: '0'
+    iq_balance_mode13: '0'
+    iq_balance_mode14: '0'
+    iq_balance_mode15: '0'
+    iq_balance_mode16: '0'
+    iq_balance_mode17: '0'
+    iq_balance_mode18: '0'
+    iq_balance_mode19: '0'
+    iq_balance_mode2: '0'
+    iq_balance_mode20: '0'
+    iq_balance_mode21: '0'
+    iq_balance_mode22: '0'
+    iq_balance_mode23: '0'
+    iq_balance_mode24: '0'
+    iq_balance_mode25: '0'
+    iq_balance_mode26: '0'
+    iq_balance_mode27: '0'
+    iq_balance_mode28: '0'
+    iq_balance_mode29: '0'
+    iq_balance_mode3: '0'
+    iq_balance_mode30: '0'
+    iq_balance_mode31: '0'
+    iq_balance_mode4: '0'
+    iq_balance_mode5: '0'
+    iq_balance_mode6: '0'
+    iq_balance_mode7: '0'
+    iq_balance_mode8: '0'
+    iq_balance_mode9: '0'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    nchan: '1'
+    num_mboards: '1'
+    sample_rate: samp_rate
+    sync: sync
+    time_source0: ''
+    time_source1: ''
+    time_source2: ''
+    time_source3: ''
+    time_source4: ''
+    time_source5: ''
+    time_source6: ''
+    time_source7: ''
+    type: fc32
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [8, 165]
+    rotation: 0
+    state: enabled
+- name: pfb_channelizer_ccf_0
+  id: pfb_channelizer_ccf
+  parameters:
+    affinity: ''
+    alias: ''
+    atten: '100'
+    bus_conns: '[[0,],]'
+    ch_map: '[]'
+    comment: ''
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    nchans: '11'
+    osr: '1.0'
+    samp_delay: '0'
+    taps: pfb_taps
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [511, 255]
+    rotation: 0
+    state: enabled
+- name: qtgui_waterfall_sink_x_0
+  id: qtgui_waterfall_sink_x
+  parameters:
+    affinity: ''
+    alias: ''
+    alpha1: '1.0'
+    alpha10: '1.0'
+    alpha2: '1.0'
+    alpha3: '1.0'
+    alpha4: '1.0'
+    alpha5: '1.0'
+    alpha6: '1.0'
+    alpha7: '1.0'
+    alpha8: '1.0'
+    alpha9: '1.0'
+    axislabels: 'True'
+    bw: samp_rate
+    color1: '0'
+    color10: '0'
+    color2: '0'
+    color3: '0'
+    color4: '0'
+    color5: '0'
+    color6: '0'
+    color7: '0'
+    color8: '0'
+    color9: '0'
+    comment: ''
+    fc: '0'
+    fftsize: '1024'
+    freqhalf: 'True'
+    grid: 'False'
+    gui_hint: ''
+    int_max: '10'
+    int_min: '-140'
+    label1: ''
+    label10: ''
+    label2: ''
+    label3: ''
+    label4: ''
+    label5: ''
+    label6: ''
+    label7: ''
+    label8: ''
+    label9: ''
+    legend: 'True'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    name: '""'
+    nconnections: '1'
+    showports: 'False'
+    type: complex
+    update_time: '0.10'
+    wintype: window.WIN_BLACKMAN_hARRIS
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [317, 139]
+    rotation: 0
+    state: true
+- name: rational_resampler_xxx_0
+  id: rational_resampler_xxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    decim: '625'
+    fbw: '0'
+    interp: '594'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    taps: ''
+    type: ccc
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [310, 446]
+    rotation: 0
+    state: enabled
+- name: rational_resampler_xxx_1
+  id: rational_resampler_xxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    decim: '3'
+    fbw: '0'
+    interp: '4'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    taps: ''
+    type: ccc
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [813, 85]
+    rotation: 0
+    state: enabled
+- name: rational_resampler_xxx_1_0
+  id: rational_resampler_xxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    decim: '3'
+    fbw: '0'
+    interp: '4'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    taps: ''
+    type: ccc
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [813, 181]
+    rotation: 0
+    state: enabled
+- name: rational_resampler_xxx_1_0_0
+  id: rational_resampler_xxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    decim: '3'
+    fbw: '0'
+    interp: '4'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    taps: ''
+    type: ccc
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [813, 277]
+    rotation: 0
+    state: enabled
+- name: rational_resampler_xxx_1_0_0_0
+  id: rational_resampler_xxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    decim: '3'
+    fbw: '0'
+    interp: '4'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    taps: ''
+    type: ccc
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [813, 557]
+    rotation: 0
+    state: enabled
+- name: rational_resampler_xxx_1_0_0_0_0
+  id: rational_resampler_xxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    decim: '3'
+    fbw: '0'
+    interp: '4'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    taps: ''
+    type: ccc
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [813, 941]
+    rotation: 0
+    state: enabled
+- name: rational_resampler_xxx_1_0_0_1
+  id: rational_resampler_xxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    decim: '3'
+    fbw: '0'
+    interp: '4'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    taps: ''
+    type: ccc
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [813, 661]
+    rotation: 0
+    state: enabled
+- name: rational_resampler_xxx_1_0_1
+  id: rational_resampler_xxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    decim: '3'
+    fbw: '0'
+    interp: '4'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    taps: ''
+    type: ccc
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [813, 461]
+    rotation: 0
+    state: enabled
+- name: rational_resampler_xxx_1_0_1_0
+  id: rational_resampler_xxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    decim: '3'
+    fbw: '0'
+    interp: '4'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    taps: ''
+    type: ccc
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [813, 845]
+    rotation: 0
+    state: enabled
+- name: rational_resampler_xxx_1_1
+  id: rational_resampler_xxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    decim: '3'
+    fbw: '0'
+    interp: '4'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    taps: ''
+    type: ccc
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [813, 365]
+    rotation: 0
+    state: enabled
+- name: rational_resampler_xxx_1_1_0
+  id: rational_resampler_xxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    decim: '3'
+    fbw: '0'
+    interp: '4'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    taps: ''
+    type: ccc
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [813, 749]
+    rotation: 0
+    state: enabled
+
+connections:
+- [blocks_pack_k_bits_bb_0, '0', blocks_udp_sink_0, '0']
+- [blocks_pack_k_bits_bb_0_0, '0', blocks_udp_sink_0_0, '0']
+- [blocks_pack_k_bits_bb_0_0_0, '0', blocks_udp_sink_0_0_0, '0']
+- [blocks_pack_k_bits_bb_0_0_0_0, '0', blocks_udp_sink_0_0_0_0, '0']
+- [blocks_pack_k_bits_bb_0_0_0_0_0, '0', blocks_udp_sink_0_0_0_0_0, '0']
+- [blocks_pack_k_bits_bb_0_0_0_1, '0', blocks_udp_sink_0_0_0_1, '0']
+- [blocks_pack_k_bits_bb_0_0_1, '0', blocks_udp_sink_0_0_1, '0']
+- [blocks_pack_k_bits_bb_0_0_1_0, '0', blocks_udp_sink_0_0_1_0, '0']
+- [blocks_pack_k_bits_bb_0_1, '0', blocks_udp_sink_0_1, '0']
+- [blocks_pack_k_bits_bb_0_1_0, '0', blocks_udp_sink_0_1_0, '0']
+- [digital_gmsk_demod_0, '0', blocks_pack_k_bits_bb_0, '0']
+- [digital_gmsk_demod_0_0, '0', blocks_pack_k_bits_bb_0_0, '0']
+- [digital_gmsk_demod_0_0_0, '0', blocks_pack_k_bits_bb_0_0_0, '0']
+- [digital_gmsk_demod_0_0_0_0, '0', blocks_pack_k_bits_bb_0_0_0_0, '0']
+- [digital_gmsk_demod_0_0_0_0_0, '0', blocks_pack_k_bits_bb_0_0_0_0_0, '0']
+- [digital_gmsk_demod_0_0_0_1, '0', blocks_pack_k_bits_bb_0_0_0_1, '0']
+- [digital_gmsk_demod_0_0_1, '0', blocks_pack_k_bits_bb_0_0_1, '0']
+- [digital_gmsk_demod_0_0_1_0, '0', blocks_pack_k_bits_bb_0_0_1_0, '0']
+- [digital_gmsk_demod_0_1, '0', blocks_pack_k_bits_bb_0_1, '0']
+- [digital_gmsk_demod_0_1_0, '0', blocks_pack_k_bits_bb_0_1_0, '0']
+- [osmosdr_source_0, '0', qtgui_waterfall_sink_x_0, '0']
+- [osmosdr_source_0, '0', rational_resampler_xxx_0, '0']
+- [pfb_channelizer_ccf_0, '0', blocks_null_sink_0, '0']
+- [pfb_channelizer_ccf_0, '1', rational_resampler_xxx_1, '0']
+- [pfb_channelizer_ccf_0, '10', rational_resampler_xxx_1_0_0_0_0, '0']
+- [pfb_channelizer_ccf_0, '2', rational_resampler_xxx_1_0, '0']
+- [pfb_channelizer_ccf_0, '3', rational_resampler_xxx_1_0_0, '0']
+- [pfb_channelizer_ccf_0, '4', rational_resampler_xxx_1_1, '0']
+- [pfb_channelizer_ccf_0, '5', rational_resampler_xxx_1_0_1, '0']
+- [pfb_channelizer_ccf_0, '6', rational_resampler_xxx_1_0_0_0, '0']
+- [pfb_channelizer_ccf_0, '7', rational_resampler_xxx_1_0_0_1, '0']
+- [pfb_channelizer_ccf_0, '8', rational_resampler_xxx_1_1_0, '0']
+- [pfb_channelizer_ccf_0, '9', rational_resampler_xxx_1_0_1_0, '0']
+- [rational_resampler_xxx_0, '0', pfb_channelizer_ccf_0, '0']
+- [rational_resampler_xxx_1, '0', digital_gmsk_demod_0, '0']
+- [rational_resampler_xxx_1_0, '0', digital_gmsk_demod_0_0, '0']
+- [rational_resampler_xxx_1_0_0, '0', digital_gmsk_demod_0_0_0, '0']
+- [rational_resampler_xxx_1_0_0_0, '0', digital_gmsk_demod_0_0_0_0, '0']
+- [rational_resampler_xxx_1_0_0_0_0, '0', digital_gmsk_demod_0_0_0_0_0, '0']
+- [rational_resampler_xxx_1_0_0_1, '0', digital_gmsk_demod_0_0_0_1, '0']
+- [rational_resampler_xxx_1_0_1, '0', digital_gmsk_demod_0_0_1, '0']
+- [rational_resampler_xxx_1_0_1_0, '0', digital_gmsk_demod_0_0_1_0, '0']
+- [rational_resampler_xxx_1_1, '0', digital_gmsk_demod_0_1, '0']
+- [rational_resampler_xxx_1_1_0, '0', digital_gmsk_demod_0_1_0, '0']
+
+metadata:
+  file_format: 1

--- a/SDR/dect_multirx_310.py
+++ b/SDR/dect_multirx_310.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+#
+# SPDX-License-Identifier: GPL-3.0
+#
+# GNU Radio Python Flow Graph
+# Title: Dect Multirx 310
+# GNU Radio version: 3.10.9.2
+
+from PyQt5 import Qt
+from gnuradio import qtgui
+from PyQt5 import QtCore
+from gnuradio import blocks
+from gnuradio import digital
+from gnuradio import filter
+from gnuradio.filter import firdes
+from gnuradio import gr
+from gnuradio.fft import window
+import sys
+import signal
+from PyQt5 import Qt
+from argparse import ArgumentParser
+from gnuradio.eng_arg import eng_float, intx
+from gnuradio import eng_notation
+from gnuradio import network
+from gnuradio.filter import pfb
+import osmosdr
+import time
+import sip
+
+
+
+class dect_multirx_310(gr.top_block, Qt.QWidget):
+
+    def __init__(self):
+        gr.top_block.__init__(self, "Dect Multirx 310", catch_exceptions=True)
+        Qt.QWidget.__init__(self)
+        self.setWindowTitle("Dect Multirx 310")
+        qtgui.util.check_set_qss()
+        try:
+            self.setWindowIcon(Qt.QIcon.fromTheme('gnuradio-grc'))
+        except BaseException as exc:
+            print(f"Qt GUI: Could not set Icon: {str(exc)}", file=sys.stderr)
+        self.top_scroll_layout = Qt.QVBoxLayout()
+        self.setLayout(self.top_scroll_layout)
+        self.top_scroll = Qt.QScrollArea()
+        self.top_scroll.setFrameStyle(Qt.QFrame.NoFrame)
+        self.top_scroll_layout.addWidget(self.top_scroll)
+        self.top_scroll.setWidgetResizable(True)
+        self.top_widget = Qt.QWidget()
+        self.top_scroll.setWidget(self.top_widget)
+        self.top_layout = Qt.QVBoxLayout(self.top_widget)
+        self.top_grid_layout = Qt.QGridLayout()
+        self.top_layout.addLayout(self.top_grid_layout)
+
+        self.settings = Qt.QSettings("GNU Radio", "dect_multirx_310")
+
+        try:
+            geometry = self.settings.value("geometry")
+            if geometry:
+                self.restoreGeometry(geometry)
+        except BaseException as exc:
+            print(f"Qt GUI: Could not restore geometry: {str(exc)}", file=sys.stderr)
+
+        ##################################################
+        # Variables
+        ##################################################
+        self.symbol_rate = symbol_rate = 1.152e6
+        self.samp_rate = samp_rate = 20e6
+        self.rf_gain = rf_gain = 10
+        self.ppm = ppm = 0
+        self.if_gain = if_gain = 20
+        self.channels = channels = 11
+        self.ch_tb = ch_tb = 1.728e6-symbol_rate
+        self.ch_bw = ch_bw = 1.728e6
+        self.bb_gain = bb_gain = 20
+        self.atten = atten = 60
+        self.total_bw = total_bw = ch_bw*channels
+        self.range_rf_gain = range_rf_gain = rf_gain
+        self.range_ppm = range_ppm = ppm
+        self.range_if_gain = range_if_gain = if_gain
+        self.range_bb_gain = range_bb_gain = bb_gain
+        self.pfb_taps = pfb_taps = firdes.low_pass_2(1, samp_rate, ch_bw, ch_tb, atten, window.WIN_HANN)
+        self.bb_freq = bb_freq = 1897.344e6-(5*1.728e6)
+
+        ##################################################
+        # Blocks
+        ##################################################
+
+        self.rational_resampler_xxx_1_1_0 = filter.rational_resampler_ccc(
+                interpolation=4,
+                decimation=3,
+                taps=[],
+                fractional_bw=0)
+        self.rational_resampler_xxx_1_1 = filter.rational_resampler_ccc(
+                interpolation=4,
+                decimation=3,
+                taps=[],
+                fractional_bw=0)
+        self.rational_resampler_xxx_1_0_1_0 = filter.rational_resampler_ccc(
+                interpolation=4,
+                decimation=3,
+                taps=[],
+                fractional_bw=0)
+        self.rational_resampler_xxx_1_0_1 = filter.rational_resampler_ccc(
+                interpolation=4,
+                decimation=3,
+                taps=[],
+                fractional_bw=0)
+        self.rational_resampler_xxx_1_0_0_1 = filter.rational_resampler_ccc(
+                interpolation=4,
+                decimation=3,
+                taps=[],
+                fractional_bw=0)
+        self.rational_resampler_xxx_1_0_0_0_0 = filter.rational_resampler_ccc(
+                interpolation=4,
+                decimation=3,
+                taps=[],
+                fractional_bw=0)
+        self.rational_resampler_xxx_1_0_0_0 = filter.rational_resampler_ccc(
+                interpolation=4,
+                decimation=3,
+                taps=[],
+                fractional_bw=0)
+        self.rational_resampler_xxx_1_0_0 = filter.rational_resampler_ccc(
+                interpolation=4,
+                decimation=3,
+                taps=[],
+                fractional_bw=0)
+        self.rational_resampler_xxx_1_0 = filter.rational_resampler_ccc(
+                interpolation=4,
+                decimation=3,
+                taps=[],
+                fractional_bw=0)
+        self.rational_resampler_xxx_1 = filter.rational_resampler_ccc(
+                interpolation=4,
+                decimation=3,
+                taps=[],
+                fractional_bw=0)
+        self.rational_resampler_xxx_0 = filter.rational_resampler_ccc(
+                interpolation=594,
+                decimation=625,
+                taps=[],
+                fractional_bw=0)
+        self._range_rf_gain_range = qtgui.Range(0, 100, 1, rf_gain, 200)
+        self._range_rf_gain_win = qtgui.RangeWidget(self._range_rf_gain_range, self.set_range_rf_gain, "RF Gain", "counter_slider", float, QtCore.Qt.Horizontal)
+        self.top_layout.addWidget(self._range_rf_gain_win)
+        self._range_ppm_range = qtgui.Range(-70, 70, 1, ppm, 200)
+        self._range_ppm_win = qtgui.RangeWidget(self._range_ppm_range, self.set_range_ppm, "PPM", "counter_slider", float, QtCore.Qt.Horizontal)
+        self.top_layout.addWidget(self._range_ppm_win)
+        self._range_if_gain_range = qtgui.Range(0, 100, 1, if_gain, 200)
+        self._range_if_gain_win = qtgui.RangeWidget(self._range_if_gain_range, self.set_range_if_gain, "IF Gain", "counter_slider", float, QtCore.Qt.Horizontal)
+        self.top_layout.addWidget(self._range_if_gain_win)
+        self._range_bb_gain_range = qtgui.Range(0, 100, 1, bb_gain, 200)
+        self._range_bb_gain_win = qtgui.RangeWidget(self._range_bb_gain_range, self.set_range_bb_gain, "BB Gain", "counter_slider", float, QtCore.Qt.Horizontal)
+        self.top_layout.addWidget(self._range_bb_gain_win)
+        self.qtgui_waterfall_sink_x_0 = qtgui.waterfall_sink_c(
+            1024, #size
+            window.WIN_BLACKMAN_hARRIS, #wintype
+            0, #fc
+            samp_rate, #bw
+            "", #name
+            1, #number of inputs
+            None # parent
+        )
+        self.qtgui_waterfall_sink_x_0.set_update_time(0.10)
+        self.qtgui_waterfall_sink_x_0.enable_grid(False)
+        self.qtgui_waterfall_sink_x_0.enable_axis_labels(True)
+
+
+
+        labels = ['', '', '', '', '',
+                  '', '', '', '', '']
+        colors = [0, 0, 0, 0, 0,
+                  0, 0, 0, 0, 0]
+        alphas = [1.0, 1.0, 1.0, 1.0, 1.0,
+                  1.0, 1.0, 1.0, 1.0, 1.0]
+
+        for i in range(1):
+            if len(labels[i]) == 0:
+                self.qtgui_waterfall_sink_x_0.set_line_label(i, "Data {0}".format(i))
+            else:
+                self.qtgui_waterfall_sink_x_0.set_line_label(i, labels[i])
+            self.qtgui_waterfall_sink_x_0.set_color_map(i, colors[i])
+            self.qtgui_waterfall_sink_x_0.set_line_alpha(i, alphas[i])
+
+        self.qtgui_waterfall_sink_x_0.set_intensity_range(-140, 10)
+
+        self._qtgui_waterfall_sink_x_0_win = sip.wrapinstance(self.qtgui_waterfall_sink_x_0.qwidget(), Qt.QWidget)
+
+        self.top_layout.addWidget(self._qtgui_waterfall_sink_x_0_win)
+        self.pfb_channelizer_ccf_0 = pfb.channelizer_ccf(
+            11,
+            pfb_taps,
+            1.0,
+            100)
+        self.pfb_channelizer_ccf_0.set_channel_map([])
+        self.pfb_channelizer_ccf_0.declare_sample_delay(0)
+        self.osmosdr_source_0 = osmosdr.source(
+            args="numchan=" + str(1) + " " + ''
+        )
+        self.osmosdr_source_0.set_time_unknown_pps(osmosdr.time_spec_t())
+        self.osmosdr_source_0.set_sample_rate(samp_rate)
+        self.osmosdr_source_0.set_center_freq(bb_freq, 0)
+        self.osmosdr_source_0.set_freq_corr(ppm, 0)
+        self.osmosdr_source_0.set_dc_offset_mode(0, 0)
+        self.osmosdr_source_0.set_iq_balance_mode(0, 0)
+        self.osmosdr_source_0.set_gain_mode(False, 0)
+        self.osmosdr_source_0.set_gain(rf_gain, 0)
+        self.osmosdr_source_0.set_if_gain(if_gain, 0)
+        self.osmosdr_source_0.set_bb_gain(bb_gain, 0)
+        self.osmosdr_source_0.set_antenna('', 0)
+        self.osmosdr_source_0.set_bandwidth(20e6, 0)
+        self.digital_gmsk_demod_0_1_0 = digital.gmsk_demod(
+            samples_per_symbol=2,
+            gain_mu=0.175,
+            mu=0.5,
+            omega_relative_limit=0.005,
+            freq_error=0,
+            verbose=False,log=False)
+        self.digital_gmsk_demod_0_1 = digital.gmsk_demod(
+            samples_per_symbol=2,
+            gain_mu=0.175,
+            mu=0.5,
+            omega_relative_limit=0.005,
+            freq_error=0,
+            verbose=False,log=False)
+        self.digital_gmsk_demod_0_0_1_0 = digital.gmsk_demod(
+            samples_per_symbol=2,
+            gain_mu=0.175,
+            mu=0.5,
+            omega_relative_limit=0.005,
+            freq_error=0,
+            verbose=False,log=False)
+        self.digital_gmsk_demod_0_0_1 = digital.gmsk_demod(
+            samples_per_symbol=2,
+            gain_mu=0.175,
+            mu=0.5,
+            omega_relative_limit=0.005,
+            freq_error=0,
+            verbose=False,log=False)
+        self.digital_gmsk_demod_0_0_0_1 = digital.gmsk_demod(
+            samples_per_symbol=2,
+            gain_mu=0.175,
+            mu=0.5,
+            omega_relative_limit=0.005,
+            freq_error=0,
+            verbose=False,log=False)
+        self.digital_gmsk_demod_0_0_0_0_0 = digital.gmsk_demod(
+            samples_per_symbol=2,
+            gain_mu=0.175,
+            mu=0.5,
+            omega_relative_limit=0.005,
+            freq_error=0,
+            verbose=False,log=False)
+        self.digital_gmsk_demod_0_0_0_0 = digital.gmsk_demod(
+            samples_per_symbol=2,
+            gain_mu=0.175,
+            mu=0.5,
+            omega_relative_limit=0.005,
+            freq_error=0,
+            verbose=False,log=False)
+        self.digital_gmsk_demod_0_0_0 = digital.gmsk_demod(
+            samples_per_symbol=2,
+            gain_mu=0.175,
+            mu=0.5,
+            omega_relative_limit=0.005,
+            freq_error=0,
+            verbose=False,log=False)
+        self.digital_gmsk_demod_0_0 = digital.gmsk_demod(
+            samples_per_symbol=2,
+            gain_mu=0.175,
+            mu=0.5,
+            omega_relative_limit=0.005,
+            freq_error=0,
+            verbose=False,log=False)
+        self.digital_gmsk_demod_0 = digital.gmsk_demod(
+            samples_per_symbol=2,
+            gain_mu=0.175,
+            mu=0.5,
+            omega_relative_limit=0.005,
+            freq_error=0,
+            verbose=False,log=False)
+        self.blocks_udp_sink_0_1_0 = network.udp_sink(gr.sizeof_char, 1, '127.0.0.1', 2330, 0, 1472, True)
+        self.blocks_udp_sink_0_1 = network.udp_sink(gr.sizeof_char, 1, '127.0.0.1', 2326, 0, 1472, True)
+        self.blocks_udp_sink_0_0_1_0 = network.udp_sink(gr.sizeof_char, 1, '127.0.0.1', 2331, 0, 1472, True)
+        self.blocks_udp_sink_0_0_1 = network.udp_sink(gr.sizeof_char, 1, '127.0.0.1', 2327, 0, 1472, True)
+        self.blocks_udp_sink_0_0_0_1 = network.udp_sink(gr.sizeof_char, 1, '127.0.0.1', 2329, 0, 1472, True)
+        self.blocks_udp_sink_0_0_0_0_0 = network.udp_sink(gr.sizeof_char, 1, '127.0.0.1', 2332, 0, 1472, True)
+        self.blocks_udp_sink_0_0_0_0 = network.udp_sink(gr.sizeof_char, 1, '127.0.0.1', 2328, 0, 1472, True)
+        self.blocks_udp_sink_0_0_0 = network.udp_sink(gr.sizeof_char, 1, '127.0.0.1', 2325, 0, 1472, True)
+        self.blocks_udp_sink_0_0 = network.udp_sink(gr.sizeof_char, 1, '127.0.0.1', 2324, 0, 1472, True)
+        self.blocks_udp_sink_0 = network.udp_sink(gr.sizeof_char, 1, '127.0.0.1', 2323, 0, 1472, True)
+        self.blocks_pack_k_bits_bb_0_1_0 = blocks.pack_k_bits_bb(8)
+        self.blocks_pack_k_bits_bb_0_1 = blocks.pack_k_bits_bb(8)
+        self.blocks_pack_k_bits_bb_0_0_1_0 = blocks.pack_k_bits_bb(8)
+        self.blocks_pack_k_bits_bb_0_0_1 = blocks.pack_k_bits_bb(8)
+        self.blocks_pack_k_bits_bb_0_0_0_1 = blocks.pack_k_bits_bb(8)
+        self.blocks_pack_k_bits_bb_0_0_0_0_0 = blocks.pack_k_bits_bb(8)
+        self.blocks_pack_k_bits_bb_0_0_0_0 = blocks.pack_k_bits_bb(8)
+        self.blocks_pack_k_bits_bb_0_0_0 = blocks.pack_k_bits_bb(8)
+        self.blocks_pack_k_bits_bb_0_0 = blocks.pack_k_bits_bb(8)
+        self.blocks_pack_k_bits_bb_0 = blocks.pack_k_bits_bb(8)
+        self.blocks_null_sink_0 = blocks.null_sink(gr.sizeof_gr_complex*1)
+
+
+        ##################################################
+        # Connections
+        ##################################################
+        self.connect((self.blocks_pack_k_bits_bb_0, 0), (self.blocks_udp_sink_0, 0))
+        self.connect((self.blocks_pack_k_bits_bb_0_0, 0), (self.blocks_udp_sink_0_0, 0))
+        self.connect((self.blocks_pack_k_bits_bb_0_0_0, 0), (self.blocks_udp_sink_0_0_0, 0))
+        self.connect((self.blocks_pack_k_bits_bb_0_0_0_0, 0), (self.blocks_udp_sink_0_0_0_0, 0))
+        self.connect((self.blocks_pack_k_bits_bb_0_0_0_0_0, 0), (self.blocks_udp_sink_0_0_0_0_0, 0))
+        self.connect((self.blocks_pack_k_bits_bb_0_0_0_1, 0), (self.blocks_udp_sink_0_0_0_1, 0))
+        self.connect((self.blocks_pack_k_bits_bb_0_0_1, 0), (self.blocks_udp_sink_0_0_1, 0))
+        self.connect((self.blocks_pack_k_bits_bb_0_0_1_0, 0), (self.blocks_udp_sink_0_0_1_0, 0))
+        self.connect((self.blocks_pack_k_bits_bb_0_1, 0), (self.blocks_udp_sink_0_1, 0))
+        self.connect((self.blocks_pack_k_bits_bb_0_1_0, 0), (self.blocks_udp_sink_0_1_0, 0))
+        self.connect((self.digital_gmsk_demod_0, 0), (self.blocks_pack_k_bits_bb_0, 0))
+        self.connect((self.digital_gmsk_demod_0_0, 0), (self.blocks_pack_k_bits_bb_0_0, 0))
+        self.connect((self.digital_gmsk_demod_0_0_0, 0), (self.blocks_pack_k_bits_bb_0_0_0, 0))
+        self.connect((self.digital_gmsk_demod_0_0_0_0, 0), (self.blocks_pack_k_bits_bb_0_0_0_0, 0))
+        self.connect((self.digital_gmsk_demod_0_0_0_0_0, 0), (self.blocks_pack_k_bits_bb_0_0_0_0_0, 0))
+        self.connect((self.digital_gmsk_demod_0_0_0_1, 0), (self.blocks_pack_k_bits_bb_0_0_0_1, 0))
+        self.connect((self.digital_gmsk_demod_0_0_1, 0), (self.blocks_pack_k_bits_bb_0_0_1, 0))
+        self.connect((self.digital_gmsk_demod_0_0_1_0, 0), (self.blocks_pack_k_bits_bb_0_0_1_0, 0))
+        self.connect((self.digital_gmsk_demod_0_1, 0), (self.blocks_pack_k_bits_bb_0_1, 0))
+        self.connect((self.digital_gmsk_demod_0_1_0, 0), (self.blocks_pack_k_bits_bb_0_1_0, 0))
+        self.connect((self.osmosdr_source_0, 0), (self.qtgui_waterfall_sink_x_0, 0))
+        self.connect((self.osmosdr_source_0, 0), (self.rational_resampler_xxx_0, 0))
+        self.connect((self.pfb_channelizer_ccf_0, 0), (self.blocks_null_sink_0, 0))
+        self.connect((self.pfb_channelizer_ccf_0, 1), (self.rational_resampler_xxx_1, 0))
+        self.connect((self.pfb_channelizer_ccf_0, 2), (self.rational_resampler_xxx_1_0, 0))
+        self.connect((self.pfb_channelizer_ccf_0, 3), (self.rational_resampler_xxx_1_0_0, 0))
+        self.connect((self.pfb_channelizer_ccf_0, 6), (self.rational_resampler_xxx_1_0_0_0, 0))
+        self.connect((self.pfb_channelizer_ccf_0, 10), (self.rational_resampler_xxx_1_0_0_0_0, 0))
+        self.connect((self.pfb_channelizer_ccf_0, 7), (self.rational_resampler_xxx_1_0_0_1, 0))
+        self.connect((self.pfb_channelizer_ccf_0, 5), (self.rational_resampler_xxx_1_0_1, 0))
+        self.connect((self.pfb_channelizer_ccf_0, 9), (self.rational_resampler_xxx_1_0_1_0, 0))
+        self.connect((self.pfb_channelizer_ccf_0, 4), (self.rational_resampler_xxx_1_1, 0))
+        self.connect((self.pfb_channelizer_ccf_0, 8), (self.rational_resampler_xxx_1_1_0, 0))
+        self.connect((self.rational_resampler_xxx_0, 0), (self.pfb_channelizer_ccf_0, 0))
+        self.connect((self.rational_resampler_xxx_1, 0), (self.digital_gmsk_demod_0, 0))
+        self.connect((self.rational_resampler_xxx_1_0, 0), (self.digital_gmsk_demod_0_0, 0))
+        self.connect((self.rational_resampler_xxx_1_0_0, 0), (self.digital_gmsk_demod_0_0_0, 0))
+        self.connect((self.rational_resampler_xxx_1_0_0_0, 0), (self.digital_gmsk_demod_0_0_0_0, 0))
+        self.connect((self.rational_resampler_xxx_1_0_0_0_0, 0), (self.digital_gmsk_demod_0_0_0_0_0, 0))
+        self.connect((self.rational_resampler_xxx_1_0_0_1, 0), (self.digital_gmsk_demod_0_0_0_1, 0))
+        self.connect((self.rational_resampler_xxx_1_0_1, 0), (self.digital_gmsk_demod_0_0_1, 0))
+        self.connect((self.rational_resampler_xxx_1_0_1_0, 0), (self.digital_gmsk_demod_0_0_1_0, 0))
+        self.connect((self.rational_resampler_xxx_1_1, 0), (self.digital_gmsk_demod_0_1, 0))
+        self.connect((self.rational_resampler_xxx_1_1_0, 0), (self.digital_gmsk_demod_0_1_0, 0))
+
+
+    def closeEvent(self, event):
+        self.settings = Qt.QSettings("GNU Radio", "dect_multirx_310")
+        self.settings.setValue("geometry", self.saveGeometry())
+        self.stop()
+        self.wait()
+
+        event.accept()
+
+    def get_symbol_rate(self):
+        return self.symbol_rate
+
+    def set_symbol_rate(self, symbol_rate):
+        self.symbol_rate = symbol_rate
+        self.set_ch_tb(1.728e6-self.symbol_rate)
+
+    def get_samp_rate(self):
+        return self.samp_rate
+
+    def set_samp_rate(self, samp_rate):
+        self.samp_rate = samp_rate
+        self.set_pfb_taps(firdes.low_pass_2(1, self.samp_rate, self.ch_bw, self.ch_tb, self.atten, window.WIN_HANN))
+        self.osmosdr_source_0.set_sample_rate(self.samp_rate)
+        self.qtgui_waterfall_sink_x_0.set_frequency_range(0, self.samp_rate)
+
+    def get_rf_gain(self):
+        return self.rf_gain
+
+    def set_rf_gain(self, rf_gain):
+        self.rf_gain = rf_gain
+        self.set_range_rf_gain(self.rf_gain)
+        self.osmosdr_source_0.set_gain(self.rf_gain, 0)
+
+    def get_ppm(self):
+        return self.ppm
+
+    def set_ppm(self, ppm):
+        self.ppm = ppm
+        self.set_range_ppm(self.ppm)
+        self.osmosdr_source_0.set_freq_corr(self.ppm, 0)
+
+    def get_if_gain(self):
+        return self.if_gain
+
+    def set_if_gain(self, if_gain):
+        self.if_gain = if_gain
+        self.set_range_if_gain(self.if_gain)
+        self.osmosdr_source_0.set_if_gain(self.if_gain, 0)
+
+    def get_channels(self):
+        return self.channels
+
+    def set_channels(self, channels):
+        self.channels = channels
+        self.set_total_bw(self.ch_bw*self.channels)
+
+    def get_ch_tb(self):
+        return self.ch_tb
+
+    def set_ch_tb(self, ch_tb):
+        self.ch_tb = ch_tb
+        self.set_pfb_taps(firdes.low_pass_2(1, self.samp_rate, self.ch_bw, self.ch_tb, self.atten, window.WIN_HANN))
+
+    def get_ch_bw(self):
+        return self.ch_bw
+
+    def set_ch_bw(self, ch_bw):
+        self.ch_bw = ch_bw
+        self.set_pfb_taps(firdes.low_pass_2(1, self.samp_rate, self.ch_bw, self.ch_tb, self.atten, window.WIN_HANN))
+        self.set_total_bw(self.ch_bw*self.channels)
+
+    def get_bb_gain(self):
+        return self.bb_gain
+
+    def set_bb_gain(self, bb_gain):
+        self.bb_gain = bb_gain
+        self.set_range_bb_gain(self.bb_gain)
+        self.osmosdr_source_0.set_bb_gain(self.bb_gain, 0)
+
+    def get_atten(self):
+        return self.atten
+
+    def set_atten(self, atten):
+        self.atten = atten
+        self.set_pfb_taps(firdes.low_pass_2(1, self.samp_rate, self.ch_bw, self.ch_tb, self.atten, window.WIN_HANN))
+
+    def get_total_bw(self):
+        return self.total_bw
+
+    def set_total_bw(self, total_bw):
+        self.total_bw = total_bw
+
+    def get_range_rf_gain(self):
+        return self.range_rf_gain
+
+    def set_range_rf_gain(self, range_rf_gain):
+        self.range_rf_gain = range_rf_gain
+
+    def get_range_ppm(self):
+        return self.range_ppm
+
+    def set_range_ppm(self, range_ppm):
+        self.range_ppm = range_ppm
+
+    def get_range_if_gain(self):
+        return self.range_if_gain
+
+    def set_range_if_gain(self, range_if_gain):
+        self.range_if_gain = range_if_gain
+
+    def get_range_bb_gain(self):
+        return self.range_bb_gain
+
+    def set_range_bb_gain(self, range_bb_gain):
+        self.range_bb_gain = range_bb_gain
+
+    def get_pfb_taps(self):
+        return self.pfb_taps
+
+    def set_pfb_taps(self, pfb_taps):
+        self.pfb_taps = pfb_taps
+        self.pfb_channelizer_ccf_0.set_taps(self.pfb_taps)
+
+    def get_bb_freq(self):
+        return self.bb_freq
+
+    def set_bb_freq(self, bb_freq):
+        self.bb_freq = bb_freq
+        self.osmosdr_source_0.set_center_freq(self.bb_freq, 0)
+
+
+
+
+def main(top_block_cls=dect_multirx_310, options=None):
+
+    qapp = Qt.QApplication(sys.argv)
+
+    tb = top_block_cls()
+
+    tb.start()
+
+    tb.show()
+
+    def sig_handler(sig=None, frame=None):
+        tb.stop()
+        tb.wait()
+
+        Qt.QApplication.quit()
+
+    signal.signal(signal.SIGINT, sig_handler)
+    signal.signal(signal.SIGTERM, sig_handler)
+
+    timer = Qt.QTimer()
+    timer.start(500)
+    timer.timeout.connect(lambda: None)
+
+    qapp.exec_()
+
+if __name__ == '__main__':
+    main()

--- a/SDR/dectrx_310.grc
+++ b/SDR/dectrx_310.grc
@@ -1,0 +1,894 @@
+options:
+  parameters:
+    author: ''
+    category: Custom
+    cmake_opt: ''
+    comment: ''
+    copyright: ''
+    description: ''
+    gen_cmake: 'On'
+    gen_linking: dynamic
+    generate_options: qt_gui
+    hier_block_src_path: '.:'
+    id: dectrx_310
+    max_nouts: '0'
+    output_language: python
+    placement: (0,0)
+    qt_qss_theme: ''
+    realtime_scheduling: ''
+    run: 'True'
+    run_command: '{python} -u {filename}'
+    run_options: prompt
+    sizing_mode: fixed
+    thread_safe_setters: ''
+    title: ''
+    window_size: ''
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [77, 50]
+    rotation: 0
+    state: enabled
+
+blocks:
+- name: bb_gain
+  id: variable
+  parameters:
+    comment: ''
+    value: '20'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [669, 47]
+    rotation: 0
+    state: true
+- name: dect_freq
+  id: variable_qtgui_chooser
+  parameters:
+    comment: ''
+    gui_hint: ''
+    label: Carrier Number
+    label0: ch0
+    label1: ch1
+    label2: ch2
+    label3: ''
+    label4: ''
+    labels: '["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]'
+    num_opts: '0'
+    option1: '1883520000'
+    option2: '1885248000'
+    option3: '3'
+    option4: '4'
+    options: '[1897344000, 1881792000, 1883520000, 1881792000, 1886876000, 1888704000,
+      1890432000, 1892160000, 1893888000, 1895616000,]'
+    orient: Qt.QVBoxLayout
+    type: real
+    value: '1897344000'
+    widget: combo_box
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [132, 388]
+    rotation: 0
+    state: disabled
+- name: dect_rate
+  id: variable
+  parameters:
+    comment: ''
+    value: 1.152e6
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [461, 47]
+    rotation: 0
+    state: enabled
+- name: dect_ule_freq
+  id: variable_qtgui_chooser
+  parameters:
+    comment: ''
+    gui_hint: ''
+    label: Dect ULE Channel
+    label0: ''
+    label1: ''
+    label2: ''
+    label3: ''
+    label4: ''
+    labels: '["0", "1893,888", "1883,52", ]'
+    num_opts: '0'
+    option1: '1'
+    option2: '2'
+    option3: '3'
+    option4: '4'
+    options: '[0, 1893888000, 1883520000, ]'
+    orient: Qt.QVBoxLayout
+    type: real
+    value: '0'
+    widget: combo_box
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [349, 388]
+    rotation: 0
+    state: disabled
+- name: freq
+  id: variable
+  parameters:
+    comment: ''
+    value: 1897.344e6-(range_channel*1.728e6)
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [349, 47]
+    rotation: 0
+    state: enabled
+- name: if_gain
+  id: variable
+  parameters:
+    comment: ''
+    value: '20'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [845, 44]
+    rotation: 0
+    state: true
+- name: ppm
+  id: variable
+  parameters:
+    comment: ''
+    value: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [568, 51]
+    rotation: 0
+    state: true
+- name: range_bb_gain
+  id: variable_qtgui_range
+  parameters:
+    comment: ''
+    gui_hint: ''
+    label: BB Gain
+    min_len: '200'
+    orient: Qt.Horizontal
+    rangeType: float
+    start: '0'
+    step: '1'
+    stop: '100'
+    value: bb_gain
+    widget: counter_slider
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [113, 513]
+    rotation: 0
+    state: true
+- name: range_channel
+  id: variable_qtgui_range
+  parameters:
+    comment: ''
+    gui_hint: ''
+    label: Channel
+    min_len: '200'
+    orient: Qt.Horizontal
+    rangeType: float
+    start: '0'
+    step: '1'
+    stop: '9'
+    value: '5'
+    widget: counter_slider
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [374, 507]
+    rotation: 0
+    state: enabled
+- name: range_if_gain
+  id: variable_qtgui_range
+  parameters:
+    comment: ''
+    gui_hint: ''
+    label: IF Gain
+    min_len: '200'
+    orient: Qt.Horizontal
+    rangeType: float
+    start: '0'
+    step: '1'
+    stop: '100'
+    value: if_gain
+    widget: counter_slider
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [507, 512]
+    rotation: 0
+    state: true
+- name: range_ppm
+  id: variable_qtgui_range
+  parameters:
+    comment: ''
+    gui_hint: ''
+    label: PPM
+    min_len: '200'
+    orient: Qt.Horizontal
+    rangeType: float
+    start: '-70'
+    step: '1'
+    stop: '70'
+    value: ppm
+    widget: counter_slider
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [250, 510]
+    rotation: 0
+    state: true
+- name: range_rf_gain
+  id: variable_qtgui_range
+  parameters:
+    comment: ''
+    gui_hint: ''
+    label: RF Gain
+    min_len: '200'
+    orient: Qt.Horizontal
+    rangeType: float
+    start: '0'
+    step: '1'
+    stop: '100'
+    value: rf_gain
+    widget: counter_slider
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [647, 512]
+    rotation: 0
+    state: true
+- name: rf_gain
+  id: variable
+  parameters:
+    comment: ''
+    value: '10'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [761, 45]
+    rotation: 0
+    state: true
+- name: samp_rate
+  id: variable
+  parameters:
+    comment: ''
+    value: 2.4e6
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [245, 47]
+    rotation: 0
+    state: enabled
+- name: blocks_file_sink_0
+  id: blocks_file_sink
+  parameters:
+    affinity: ''
+    alias: ''
+    append: 'False'
+    comment: ''
+    file: /home/abrenn/filesink.cf32
+    type: complex
+    unbuffered: 'False'
+    vlen: '1'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1143, 388]
+    rotation: 0
+    state: disabled
+- name: blocks_pack_k_bits_bb_0
+  id: blocks_pack_k_bits_bb
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    k: '8'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [994, 353]
+    rotation: 0
+    state: enabled
+- name: blocks_udp_sink_0
+  id: network_udp_sink
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    send_eof: 'True'
+    addr: 127.0.0.1
+    port: '2323'
+    payloadsize: '1472'
+    type: byte
+    vlen: '1'
+    header: 0
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [1123, 187]
+    rotation: 0
+    state: enabled
+- name: digital_gmsk_demod_0
+  id: digital_gmsk_demod
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    freq_error: '0'
+    gain_mu: '0.175'
+    log: 'False'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    mu: '0.5'
+    omega_relative_limit: '0.005'
+    samples_per_symbol: '2'
+    verbose: 'False'
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [805, 182]
+    rotation: 0
+    state: enabled
+- name: low_pass_filter_0
+  id: low_pass_filter
+  parameters:
+    affinity: ''
+    alias: ''
+    beta: '6.76'
+    comment: ''
+    cutoff_freq: dect_rate
+    decim: '1'
+    gain: '1'
+    interp: '1'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    samp_rate: samp_rate
+    type: fir_filter_ccf
+    width: 10e3
+    win: window.WIN_HAMMING
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [615, 346]
+    rotation: 0
+    state: enabled
+- name: osmosdr_source_0
+  id: osmosdr_source
+  parameters:
+    affinity: ''
+    alias: ''
+    ant0: ''
+    ant1: ''
+    ant10: ''
+    ant11: ''
+    ant12: ''
+    ant13: ''
+    ant14: ''
+    ant15: ''
+    ant16: ''
+    ant17: ''
+    ant18: ''
+    ant19: ''
+    ant2: ''
+    ant20: ''
+    ant21: ''
+    ant22: ''
+    ant23: ''
+    ant24: ''
+    ant25: ''
+    ant26: ''
+    ant27: ''
+    ant28: ''
+    ant29: ''
+    ant3: ''
+    ant30: ''
+    ant31: ''
+    ant4: ''
+    ant5: ''
+    ant6: ''
+    ant7: ''
+    ant8: ''
+    ant9: ''
+    args: hackrf=0
+    bb_gain0: bb_gain
+    bb_gain1: '20'
+    bb_gain10: '20'
+    bb_gain11: '20'
+    bb_gain12: '20'
+    bb_gain13: '20'
+    bb_gain14: '20'
+    bb_gain15: '20'
+    bb_gain16: '20'
+    bb_gain17: '20'
+    bb_gain18: '20'
+    bb_gain19: '20'
+    bb_gain2: '20'
+    bb_gain20: '20'
+    bb_gain21: '20'
+    bb_gain22: '20'
+    bb_gain23: '20'
+    bb_gain24: '20'
+    bb_gain25: '20'
+    bb_gain26: '20'
+    bb_gain27: '20'
+    bb_gain28: '20'
+    bb_gain29: '20'
+    bb_gain3: '20'
+    bb_gain30: '20'
+    bb_gain31: '20'
+    bb_gain4: '20'
+    bb_gain5: '20'
+    bb_gain6: '20'
+    bb_gain7: '20'
+    bb_gain8: '20'
+    bb_gain9: '20'
+    bw0: dect_rate
+    bw1: '0'
+    bw10: '0'
+    bw11: '0'
+    bw12: '0'
+    bw13: '0'
+    bw14: '0'
+    bw15: '0'
+    bw16: '0'
+    bw17: '0'
+    bw18: '0'
+    bw19: '0'
+    bw2: '0'
+    bw20: '0'
+    bw21: '0'
+    bw22: '0'
+    bw23: '0'
+    bw24: '0'
+    bw25: '0'
+    bw26: '0'
+    bw27: '0'
+    bw28: '0'
+    bw29: '0'
+    bw3: '0'
+    bw30: '0'
+    bw31: '0'
+    bw4: '0'
+    bw5: '0'
+    bw6: '0'
+    bw7: '0'
+    bw8: '0'
+    bw9: '0'
+    clock_source0: ''
+    clock_source1: ''
+    clock_source2: ''
+    clock_source3: ''
+    clock_source4: ''
+    clock_source5: ''
+    clock_source6: ''
+    clock_source7: ''
+    comment: ''
+    corr0: ppm
+    corr1: '0'
+    corr10: '0'
+    corr11: '0'
+    corr12: '0'
+    corr13: '0'
+    corr14: '0'
+    corr15: '0'
+    corr16: '0'
+    corr17: '0'
+    corr18: '0'
+    corr19: '0'
+    corr2: '0'
+    corr20: '0'
+    corr21: '0'
+    corr22: '0'
+    corr23: '0'
+    corr24: '0'
+    corr25: '0'
+    corr26: '0'
+    corr27: '0'
+    corr28: '0'
+    corr29: '0'
+    corr3: '0'
+    corr30: '0'
+    corr31: '0'
+    corr4: '0'
+    corr5: '0'
+    corr6: '0'
+    corr7: '0'
+    corr8: '0'
+    corr9: '0'
+    dc_offset_mode0: '0'
+    dc_offset_mode1: '0'
+    dc_offset_mode10: '0'
+    dc_offset_mode11: '0'
+    dc_offset_mode12: '0'
+    dc_offset_mode13: '0'
+    dc_offset_mode14: '0'
+    dc_offset_mode15: '0'
+    dc_offset_mode16: '0'
+    dc_offset_mode17: '0'
+    dc_offset_mode18: '0'
+    dc_offset_mode19: '0'
+    dc_offset_mode2: '0'
+    dc_offset_mode20: '0'
+    dc_offset_mode21: '0'
+    dc_offset_mode22: '0'
+    dc_offset_mode23: '0'
+    dc_offset_mode24: '0'
+    dc_offset_mode25: '0'
+    dc_offset_mode26: '0'
+    dc_offset_mode27: '0'
+    dc_offset_mode28: '0'
+    dc_offset_mode29: '0'
+    dc_offset_mode3: '0'
+    dc_offset_mode30: '0'
+    dc_offset_mode31: '0'
+    dc_offset_mode4: '0'
+    dc_offset_mode5: '0'
+    dc_offset_mode6: '0'
+    dc_offset_mode7: '0'
+    dc_offset_mode8: '0'
+    dc_offset_mode9: '0'
+    freq0: freq
+    freq1: 100e6
+    freq10: 100e6
+    freq11: 100e6
+    freq12: 100e6
+    freq13: 100e6
+    freq14: 100e6
+    freq15: 100e6
+    freq16: 100e6
+    freq17: 100e6
+    freq18: 100e6
+    freq19: 100e6
+    freq2: 100e6
+    freq20: 100e6
+    freq21: 100e6
+    freq22: 100e6
+    freq23: 100e6
+    freq24: 100e6
+    freq25: 100e6
+    freq26: 100e6
+    freq27: 100e6
+    freq28: 100e6
+    freq29: 100e6
+    freq3: 100e6
+    freq30: 100e6
+    freq31: 100e6
+    freq4: 100e6
+    freq5: 100e6
+    freq6: 100e6
+    freq7: 100e6
+    freq8: 100e6
+    freq9: 100e6
+    gain0: rf_gain
+    gain1: '10'
+    gain10: '10'
+    gain11: '10'
+    gain12: '10'
+    gain13: '10'
+    gain14: '10'
+    gain15: '10'
+    gain16: '10'
+    gain17: '10'
+    gain18: '10'
+    gain19: '10'
+    gain2: '10'
+    gain20: '10'
+    gain21: '10'
+    gain22: '10'
+    gain23: '10'
+    gain24: '10'
+    gain25: '10'
+    gain26: '10'
+    gain27: '10'
+    gain28: '10'
+    gain29: '10'
+    gain3: '10'
+    gain30: '10'
+    gain31: '10'
+    gain4: '10'
+    gain5: '10'
+    gain6: '10'
+    gain7: '10'
+    gain8: '10'
+    gain9: '10'
+    gain_mode0: 'True'
+    gain_mode1: 'False'
+    gain_mode10: 'False'
+    gain_mode11: 'False'
+    gain_mode12: 'False'
+    gain_mode13: 'False'
+    gain_mode14: 'False'
+    gain_mode15: 'False'
+    gain_mode16: 'False'
+    gain_mode17: 'False'
+    gain_mode18: 'False'
+    gain_mode19: 'False'
+    gain_mode2: 'False'
+    gain_mode20: 'False'
+    gain_mode21: 'False'
+    gain_mode22: 'False'
+    gain_mode23: 'False'
+    gain_mode24: 'False'
+    gain_mode25: 'False'
+    gain_mode26: 'False'
+    gain_mode27: 'False'
+    gain_mode28: 'False'
+    gain_mode29: 'False'
+    gain_mode3: 'False'
+    gain_mode30: 'False'
+    gain_mode31: 'False'
+    gain_mode4: 'False'
+    gain_mode5: 'False'
+    gain_mode6: 'False'
+    gain_mode7: 'False'
+    gain_mode8: 'False'
+    gain_mode9: 'False'
+    if_gain0: if_gain
+    if_gain1: '20'
+    if_gain10: '20'
+    if_gain11: '20'
+    if_gain12: '20'
+    if_gain13: '20'
+    if_gain14: '20'
+    if_gain15: '20'
+    if_gain16: '20'
+    if_gain17: '20'
+    if_gain18: '20'
+    if_gain19: '20'
+    if_gain2: '20'
+    if_gain20: '20'
+    if_gain21: '20'
+    if_gain22: '20'
+    if_gain23: '20'
+    if_gain24: '20'
+    if_gain25: '20'
+    if_gain26: '20'
+    if_gain27: '20'
+    if_gain28: '20'
+    if_gain29: '20'
+    if_gain3: '20'
+    if_gain30: '20'
+    if_gain31: '20'
+    if_gain4: '20'
+    if_gain5: '20'
+    if_gain6: '20'
+    if_gain7: '20'
+    if_gain8: '20'
+    if_gain9: '20'
+    iq_balance_mode0: '0'
+    iq_balance_mode1: '0'
+    iq_balance_mode10: '0'
+    iq_balance_mode11: '0'
+    iq_balance_mode12: '0'
+    iq_balance_mode13: '0'
+    iq_balance_mode14: '0'
+    iq_balance_mode15: '0'
+    iq_balance_mode16: '0'
+    iq_balance_mode17: '0'
+    iq_balance_mode18: '0'
+    iq_balance_mode19: '0'
+    iq_balance_mode2: '0'
+    iq_balance_mode20: '0'
+    iq_balance_mode21: '0'
+    iq_balance_mode22: '0'
+    iq_balance_mode23: '0'
+    iq_balance_mode24: '0'
+    iq_balance_mode25: '0'
+    iq_balance_mode26: '0'
+    iq_balance_mode27: '0'
+    iq_balance_mode28: '0'
+    iq_balance_mode29: '0'
+    iq_balance_mode3: '0'
+    iq_balance_mode30: '0'
+    iq_balance_mode31: '0'
+    iq_balance_mode4: '0'
+    iq_balance_mode5: '0'
+    iq_balance_mode6: '0'
+    iq_balance_mode7: '0'
+    iq_balance_mode8: '0'
+    iq_balance_mode9: '0'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    nchan: '1'
+    num_mboards: '1'
+    sample_rate: samp_rate
+    sync: sync
+    time_source0: ''
+    time_source1: ''
+    time_source2: ''
+    time_source3: ''
+    time_source4: ''
+    time_source5: ''
+    time_source6: ''
+    time_source7: ''
+    type: fc32
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [93, 126]
+    rotation: 0
+    state: enabled
+- name: qtgui_waterfall_sink_x_0
+  id: qtgui_waterfall_sink_x
+  parameters:
+    affinity: ''
+    alias: ''
+    alpha1: '1.0'
+    alpha10: '1.0'
+    alpha2: '1.0'
+    alpha3: '1.0'
+    alpha4: '1.0'
+    alpha5: '1.0'
+    alpha6: '1.0'
+    alpha7: '1.0'
+    alpha8: '1.0'
+    alpha9: '1.0'
+    axislabels: 'True'
+    bw: samp_rate
+    color1: '0'
+    color10: '0'
+    color2: '0'
+    color3: '0'
+    color4: '0'
+    color5: '0'
+    color6: '0'
+    color7: '0'
+    color8: '0'
+    color9: '0'
+    comment: ''
+    fc: '0'
+    fftsize: '1024'
+    freqhalf: 'True'
+    grid: 'False'
+    gui_hint: ''
+    int_max: '10'
+    int_min: '-140'
+    label1: ''
+    label10: ''
+    label2: ''
+    label3: ''
+    label4: ''
+    label5: ''
+    label6: ''
+    label7: ''
+    label8: ''
+    label9: ''
+    legend: 'True'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    name: '""'
+    nconnections: '1'
+    showports: 'False'
+    type: complex
+    update_time: '0.10'
+    wintype: window.WIN_BLACKMAN_hARRIS
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [592, 128]
+    rotation: 0
+    state: true
+- name: qtgui_waterfall_sink_x_0_0
+  id: qtgui_waterfall_sink_x
+  parameters:
+    affinity: ''
+    alias: ''
+    alpha1: '1.0'
+    alpha10: '1.0'
+    alpha2: '1.0'
+    alpha3: '1.0'
+    alpha4: '1.0'
+    alpha5: '1.0'
+    alpha6: '1.0'
+    alpha7: '1.0'
+    alpha8: '1.0'
+    alpha9: '1.0'
+    axislabels: 'True'
+    bw: samp_rate
+    color1: '0'
+    color10: '0'
+    color2: '0'
+    color3: '0'
+    color4: '0'
+    color5: '0'
+    color6: '0'
+    color7: '0'
+    color8: '0'
+    color9: '0'
+    comment: ''
+    fc: '0'
+    fftsize: '1024'
+    freqhalf: 'True'
+    grid: 'False'
+    gui_hint: ''
+    int_max: '10'
+    int_min: '-140'
+    label1: ''
+    label10: ''
+    label2: ''
+    label3: ''
+    label4: ''
+    label5: ''
+    label6: ''
+    label7: ''
+    label8: ''
+    label9: ''
+    legend: 'True'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    name: After filter
+    nconnections: '1'
+    showports: 'False'
+    type: complex
+    update_time: '0.10'
+    wintype: window.WIN_BLACKMAN_hARRIS
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [848, 471]
+    rotation: 0
+    state: true
+- name: rational_resampler_xxx_0
+  id: rational_resampler_xxx
+  parameters:
+    affinity: ''
+    alias: ''
+    comment: ''
+    decim: '25'
+    fbw: '0'
+    interp: '24'
+    maxoutbuf: '0'
+    minoutbuf: '0'
+    taps: ''
+    type: ccc
+  states:
+    bus_sink: false
+    bus_source: false
+    bus_structure: null
+    coordinate: [422, 229]
+    rotation: 0
+    state: enabled
+
+connections:
+- [blocks_pack_k_bits_bb_0, '0', blocks_udp_sink_0, '0']
+- [digital_gmsk_demod_0, '0', blocks_pack_k_bits_bb_0, '0']
+- [low_pass_filter_0, '0', blocks_file_sink_0, '0']
+- [low_pass_filter_0, '0', digital_gmsk_demod_0, '0']
+- [low_pass_filter_0, '0', qtgui_waterfall_sink_x_0_0, '0']
+- [osmosdr_source_0, '0', qtgui_waterfall_sink_x_0, '0']
+- [osmosdr_source_0, '0', rational_resampler_xxx_0, '0']
+- [rational_resampler_xxx_0, '0', low_pass_filter_0, '0']
+
+metadata:
+  file_format: 1

--- a/SDR/dectrx_310.py
+++ b/SDR/dectrx_310.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+#
+# SPDX-License-Identifier: GPL-3.0
+#
+# GNU Radio Python Flow Graph
+# Title: Dectrx 310
+# GNU Radio version: 3.10.9.2
+
+from PyQt5 import Qt
+from gnuradio import qtgui
+from PyQt5 import QtCore
+from gnuradio import blocks
+from gnuradio import digital
+from gnuradio import filter
+from gnuradio.filter import firdes
+from gnuradio import gr
+from gnuradio.fft import window
+import sys
+import signal
+from PyQt5 import Qt
+from argparse import ArgumentParser
+from gnuradio.eng_arg import eng_float, intx
+from gnuradio import eng_notation
+from gnuradio import network
+import osmosdr
+import time
+import sip
+
+
+
+class dectrx_310(gr.top_block, Qt.QWidget):
+
+    def __init__(self):
+        gr.top_block.__init__(self, "Dectrx 310", catch_exceptions=True)
+        Qt.QWidget.__init__(self)
+        self.setWindowTitle("Dectrx 310")
+        qtgui.util.check_set_qss()
+        try:
+            self.setWindowIcon(Qt.QIcon.fromTheme('gnuradio-grc'))
+        except BaseException as exc:
+            print(f"Qt GUI: Could not set Icon: {str(exc)}", file=sys.stderr)
+        self.top_scroll_layout = Qt.QVBoxLayout()
+        self.setLayout(self.top_scroll_layout)
+        self.top_scroll = Qt.QScrollArea()
+        self.top_scroll.setFrameStyle(Qt.QFrame.NoFrame)
+        self.top_scroll_layout.addWidget(self.top_scroll)
+        self.top_scroll.setWidgetResizable(True)
+        self.top_widget = Qt.QWidget()
+        self.top_scroll.setWidget(self.top_widget)
+        self.top_layout = Qt.QVBoxLayout(self.top_widget)
+        self.top_grid_layout = Qt.QGridLayout()
+        self.top_layout.addLayout(self.top_grid_layout)
+
+        self.settings = Qt.QSettings("GNU Radio", "dectrx_310")
+
+        try:
+            geometry = self.settings.value("geometry")
+            if geometry:
+                self.restoreGeometry(geometry)
+        except BaseException as exc:
+            print(f"Qt GUI: Could not restore geometry: {str(exc)}", file=sys.stderr)
+
+        ##################################################
+        # Variables
+        ##################################################
+        self.rf_gain = rf_gain = 10
+        self.range_channel = range_channel = 5
+        self.ppm = ppm = 0
+        self.if_gain = if_gain = 20
+        self.bb_gain = bb_gain = 20
+        self.samp_rate = samp_rate = 2.4e6
+        self.range_rf_gain = range_rf_gain = rf_gain
+        self.range_ppm = range_ppm = ppm
+        self.range_if_gain = range_if_gain = if_gain
+        self.range_bb_gain = range_bb_gain = bb_gain
+        self.freq = freq = 1897.344e6-(range_channel*1.728e6)
+        self.dect_rate = dect_rate = 1.152e6
+
+        ##################################################
+        # Blocks
+        ##################################################
+
+        self.rational_resampler_xxx_0 = filter.rational_resampler_ccc(
+                interpolation=24,
+                decimation=25,
+                taps=[],
+                fractional_bw=0)
+        self._range_rf_gain_range = qtgui.Range(0, 100, 1, rf_gain, 200)
+        self._range_rf_gain_win = qtgui.RangeWidget(self._range_rf_gain_range, self.set_range_rf_gain, "RF Gain", "counter_slider", float, QtCore.Qt.Horizontal)
+        self.top_layout.addWidget(self._range_rf_gain_win)
+        self._range_ppm_range = qtgui.Range(-70, 70, 1, ppm, 200)
+        self._range_ppm_win = qtgui.RangeWidget(self._range_ppm_range, self.set_range_ppm, "PPM", "counter_slider", float, QtCore.Qt.Horizontal)
+        self.top_layout.addWidget(self._range_ppm_win)
+        self._range_if_gain_range = qtgui.Range(0, 100, 1, if_gain, 200)
+        self._range_if_gain_win = qtgui.RangeWidget(self._range_if_gain_range, self.set_range_if_gain, "IF Gain", "counter_slider", float, QtCore.Qt.Horizontal)
+        self.top_layout.addWidget(self._range_if_gain_win)
+        self._range_channel_range = qtgui.Range(0, 9, 1, 5, 200)
+        self._range_channel_win = qtgui.RangeWidget(self._range_channel_range, self.set_range_channel, "Channel", "counter_slider", float, QtCore.Qt.Horizontal)
+        self.top_layout.addWidget(self._range_channel_win)
+        self._range_bb_gain_range = qtgui.Range(0, 100, 1, bb_gain, 200)
+        self._range_bb_gain_win = qtgui.RangeWidget(self._range_bb_gain_range, self.set_range_bb_gain, "BB Gain", "counter_slider", float, QtCore.Qt.Horizontal)
+        self.top_layout.addWidget(self._range_bb_gain_win)
+        self.qtgui_waterfall_sink_x_0_0 = qtgui.waterfall_sink_c(
+            1024, #size
+            window.WIN_BLACKMAN_hARRIS, #wintype
+            0, #fc
+            samp_rate, #bw
+            'After filter', #name
+            1, #number of inputs
+            None # parent
+        )
+        self.qtgui_waterfall_sink_x_0_0.set_update_time(0.10)
+        self.qtgui_waterfall_sink_x_0_0.enable_grid(False)
+        self.qtgui_waterfall_sink_x_0_0.enable_axis_labels(True)
+
+
+
+        labels = ['', '', '', '', '',
+                  '', '', '', '', '']
+        colors = [0, 0, 0, 0, 0,
+                  0, 0, 0, 0, 0]
+        alphas = [1.0, 1.0, 1.0, 1.0, 1.0,
+                  1.0, 1.0, 1.0, 1.0, 1.0]
+
+        for i in range(1):
+            if len(labels[i]) == 0:
+                self.qtgui_waterfall_sink_x_0_0.set_line_label(i, "Data {0}".format(i))
+            else:
+                self.qtgui_waterfall_sink_x_0_0.set_line_label(i, labels[i])
+            self.qtgui_waterfall_sink_x_0_0.set_color_map(i, colors[i])
+            self.qtgui_waterfall_sink_x_0_0.set_line_alpha(i, alphas[i])
+
+        self.qtgui_waterfall_sink_x_0_0.set_intensity_range(-140, 10)
+
+        self._qtgui_waterfall_sink_x_0_0_win = sip.wrapinstance(self.qtgui_waterfall_sink_x_0_0.qwidget(), Qt.QWidget)
+
+        self.top_layout.addWidget(self._qtgui_waterfall_sink_x_0_0_win)
+        self.qtgui_waterfall_sink_x_0 = qtgui.waterfall_sink_c(
+            1024, #size
+            window.WIN_BLACKMAN_hARRIS, #wintype
+            0, #fc
+            samp_rate, #bw
+            "", #name
+            1, #number of inputs
+            None # parent
+        )
+        self.qtgui_waterfall_sink_x_0.set_update_time(0.10)
+        self.qtgui_waterfall_sink_x_0.enable_grid(False)
+        self.qtgui_waterfall_sink_x_0.enable_axis_labels(True)
+
+
+
+        labels = ['', '', '', '', '',
+                  '', '', '', '', '']
+        colors = [0, 0, 0, 0, 0,
+                  0, 0, 0, 0, 0]
+        alphas = [1.0, 1.0, 1.0, 1.0, 1.0,
+                  1.0, 1.0, 1.0, 1.0, 1.0]
+
+        for i in range(1):
+            if len(labels[i]) == 0:
+                self.qtgui_waterfall_sink_x_0.set_line_label(i, "Data {0}".format(i))
+            else:
+                self.qtgui_waterfall_sink_x_0.set_line_label(i, labels[i])
+            self.qtgui_waterfall_sink_x_0.set_color_map(i, colors[i])
+            self.qtgui_waterfall_sink_x_0.set_line_alpha(i, alphas[i])
+
+        self.qtgui_waterfall_sink_x_0.set_intensity_range(-140, 10)
+
+        self._qtgui_waterfall_sink_x_0_win = sip.wrapinstance(self.qtgui_waterfall_sink_x_0.qwidget(), Qt.QWidget)
+
+        self.top_layout.addWidget(self._qtgui_waterfall_sink_x_0_win)
+        self.osmosdr_source_0 = osmosdr.source(
+            args="numchan=" + str(1) + " " + 'hackrf=0'
+        )
+        self.osmosdr_source_0.set_time_unknown_pps(osmosdr.time_spec_t())
+        self.osmosdr_source_0.set_sample_rate(samp_rate)
+        self.osmosdr_source_0.set_center_freq(freq, 0)
+        self.osmosdr_source_0.set_freq_corr(ppm, 0)
+        self.osmosdr_source_0.set_dc_offset_mode(0, 0)
+        self.osmosdr_source_0.set_iq_balance_mode(0, 0)
+        self.osmosdr_source_0.set_gain_mode(True, 0)
+        self.osmosdr_source_0.set_gain(rf_gain, 0)
+        self.osmosdr_source_0.set_if_gain(if_gain, 0)
+        self.osmosdr_source_0.set_bb_gain(bb_gain, 0)
+        self.osmosdr_source_0.set_antenna('', 0)
+        self.osmosdr_source_0.set_bandwidth(dect_rate, 0)
+        self.low_pass_filter_0 = filter.fir_filter_ccf(
+            1,
+            firdes.low_pass(
+                1,
+                samp_rate,
+                dect_rate,
+                10e3,
+                window.WIN_HAMMING,
+                6.76))
+        self.digital_gmsk_demod_0 = digital.gmsk_demod(
+            samples_per_symbol=2,
+            gain_mu=0.175,
+            mu=0.5,
+            omega_relative_limit=0.005,
+            freq_error=0,
+            verbose=False,log=False)
+        self.blocks_udp_sink_0 = network.udp_sink(gr.sizeof_char, 1, '127.0.0.1', 2323, 0, 1472, True)
+        self.blocks_pack_k_bits_bb_0 = blocks.pack_k_bits_bb(8)
+
+
+        ##################################################
+        # Connections
+        ##################################################
+        self.connect((self.blocks_pack_k_bits_bb_0, 0), (self.blocks_udp_sink_0, 0))
+        self.connect((self.digital_gmsk_demod_0, 0), (self.blocks_pack_k_bits_bb_0, 0))
+        self.connect((self.low_pass_filter_0, 0), (self.digital_gmsk_demod_0, 0))
+        self.connect((self.low_pass_filter_0, 0), (self.qtgui_waterfall_sink_x_0_0, 0))
+        self.connect((self.osmosdr_source_0, 0), (self.qtgui_waterfall_sink_x_0, 0))
+        self.connect((self.osmosdr_source_0, 0), (self.rational_resampler_xxx_0, 0))
+        self.connect((self.rational_resampler_xxx_0, 0), (self.low_pass_filter_0, 0))
+
+
+    def closeEvent(self, event):
+        self.settings = Qt.QSettings("GNU Radio", "dectrx_310")
+        self.settings.setValue("geometry", self.saveGeometry())
+        self.stop()
+        self.wait()
+
+        event.accept()
+
+    def get_rf_gain(self):
+        return self.rf_gain
+
+    def set_rf_gain(self, rf_gain):
+        self.rf_gain = rf_gain
+        self.set_range_rf_gain(self.rf_gain)
+        self.osmosdr_source_0.set_gain(self.rf_gain, 0)
+
+    def get_range_channel(self):
+        return self.range_channel
+
+    def set_range_channel(self, range_channel):
+        self.range_channel = range_channel
+        self.set_freq(1897.344e6-(self.range_channel*1.728e6))
+
+    def get_ppm(self):
+        return self.ppm
+
+    def set_ppm(self, ppm):
+        self.ppm = ppm
+        self.set_range_ppm(self.ppm)
+        self.osmosdr_source_0.set_freq_corr(self.ppm, 0)
+
+    def get_if_gain(self):
+        return self.if_gain
+
+    def set_if_gain(self, if_gain):
+        self.if_gain = if_gain
+        self.set_range_if_gain(self.if_gain)
+        self.osmosdr_source_0.set_if_gain(self.if_gain, 0)
+
+    def get_bb_gain(self):
+        return self.bb_gain
+
+    def set_bb_gain(self, bb_gain):
+        self.bb_gain = bb_gain
+        self.set_range_bb_gain(self.bb_gain)
+        self.osmosdr_source_0.set_bb_gain(self.bb_gain, 0)
+
+    def get_samp_rate(self):
+        return self.samp_rate
+
+    def set_samp_rate(self, samp_rate):
+        self.samp_rate = samp_rate
+        self.low_pass_filter_0.set_taps(firdes.low_pass(1, self.samp_rate, self.dect_rate, 10e3, window.WIN_HAMMING, 6.76))
+        self.osmosdr_source_0.set_sample_rate(self.samp_rate)
+        self.qtgui_waterfall_sink_x_0.set_frequency_range(0, self.samp_rate)
+        self.qtgui_waterfall_sink_x_0_0.set_frequency_range(0, self.samp_rate)
+
+    def get_range_rf_gain(self):
+        return self.range_rf_gain
+
+    def set_range_rf_gain(self, range_rf_gain):
+        self.range_rf_gain = range_rf_gain
+
+    def get_range_ppm(self):
+        return self.range_ppm
+
+    def set_range_ppm(self, range_ppm):
+        self.range_ppm = range_ppm
+
+    def get_range_if_gain(self):
+        return self.range_if_gain
+
+    def set_range_if_gain(self, range_if_gain):
+        self.range_if_gain = range_if_gain
+
+    def get_range_bb_gain(self):
+        return self.range_bb_gain
+
+    def set_range_bb_gain(self, range_bb_gain):
+        self.range_bb_gain = range_bb_gain
+
+    def get_freq(self):
+        return self.freq
+
+    def set_freq(self, freq):
+        self.freq = freq
+        self.osmosdr_source_0.set_center_freq(self.freq, 0)
+
+    def get_dect_rate(self):
+        return self.dect_rate
+
+    def set_dect_rate(self, dect_rate):
+        self.dect_rate = dect_rate
+        self.low_pass_filter_0.set_taps(firdes.low_pass(1, self.samp_rate, self.dect_rate, 10e3, window.WIN_HAMMING, 6.76))
+        self.osmosdr_source_0.set_bandwidth(self.dect_rate, 0)
+
+
+
+
+def main(top_block_cls=dectrx_310, options=None):
+
+    qapp = Qt.QApplication(sys.argv)
+
+    tb = top_block_cls()
+
+    tb.start()
+
+    tb.show()
+
+    def sig_handler(sig=None, frame=None):
+        tb.stop()
+        tb.wait()
+
+        Qt.QApplication.quit()
+
+    signal.signal(signal.SIGINT, sig_handler)
+    signal.signal(signal.SIGTERM, sig_handler)
+
+    timer = Qt.QTimer()
+    timer.start(500)
+    timer.timeout.connect(lambda: None)
+
+    qapp.exec_()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
A few symbols have changed since 3.8 so it needed updating for 3.10

(Notably: `blocks_udp_sink` → `network_udp_sink` and `firdes.WIN_` → `window.WIN_`)

Also I usually wouldn't create a new file to support a new version (that's what tags are for!), but I'm just following the existing style in the repository for now